### PR TITLE
edit target name in target component only

### DIFF
--- a/src/ob_component_table.tsx
+++ b/src/ob_component_table.tsx
@@ -214,6 +214,7 @@ export default function OBComponentTable(props: Props) {
         type: 'string',
         resizable: true,
         headerName: 'Target Name',
+	editable: componentName.includes('target') ? true : false,
         width: 100,
     } as GridColDef
     const target_name_semid_col = {


### PR DESCRIPTION
Minor bug on version bump. This bug does not allow you to edit target_name on the table view. Fix is to explictly allow for column editing when the view is on target component.